### PR TITLE
Only serialize id instead of the whole post object

### DIFF
--- a/src/app/vanilla-action/page.tsx
+++ b/src/app/vanilla-action/page.tsx
@@ -29,10 +29,11 @@ type PostType = NonNullable<
 >;
 
 function PostView({ post }: { post: PostType }) {
+  const { id } = post;
   async function deletePostAction() {
     "use server";
 
-    await db.delete(posts).where(eq(posts.id, post.id)); // Delete post from DB
+    await db.delete(posts).where(eq(posts.id, id)); // Delete post from DB
     revalidatePath("/vanilla-action"); // Revalidate page to see changed content
   }
 


### PR DESCRIPTION
Hey, this isn't a real pull request, but I wanted to bring the attention to this, you can make your HTML payload way smaller by serializing less data into that hidden form field